### PR TITLE
Validate also in property setter (reading fixed-width strings)

### DIFF
--- a/fixedwidth/fixedwidth.py
+++ b/fixedwidth/fixedwidth.py
@@ -149,6 +149,8 @@ class FixedWidth(object):
 
             current_pos = current_pos + config[field_name]['length']
 
+        self.line_length = current_pos - 1
+
     def update(self, **kwargs):
 
         """
@@ -306,6 +308,12 @@ class FixedWidth(object):
                 self.data[field_name] = self.config[field_name]['default']
             else:
                 self.data[field_name] = conversion[self.config[field_name]['type']](row)
+
+        # choke on too long lines
+        if (len(fw_string) > self.line_length) and (
+                str(fw_string[self.line_length:]).strip()):
+            raise ValueError("line too long (expected %d, received %d)"
+                        % (self._line_length, len(fw_string)))
 
         self.validate()
 

--- a/fixedwidth/fixedwidth.py
+++ b/fixedwidth/fixedwidth.py
@@ -307,6 +307,8 @@ class FixedWidth(object):
             else:
                 self.data[field_name] = conversion[self.config[field_name]['type']](row)
 
+        self.validate()
+
         return self.data
 
     line = property(_build_line, _string_to_dict)


### PR DESCRIPTION
This is an attempt at having more symetric behaviour. Such a change should trap mistakes earlier, so this should be benevolent. However, it will definitively behave differently for some programs, which read data but did not check whether they obeyed the specification: `'value'` attribute, `numeric` being only digits, `date`'s `'format'` to be of acceptable length...