### PR TITLE
Allow a string value as a default for date field

### DIFF
--- a/fixedwidth/fixedwidth.py
+++ b/fixedwidth/fixedwidth.py
@@ -132,6 +132,8 @@ class FixedWidth(object):
                 #ensure default value provided matches type
                 if value['type'] == 'decimal':
                     value['default'] = Decimal(value['default'])
+                elif value['type'] == 'date' and isinstance(value['default'], string_types):
+                    value['default'] = datetime.strptime(value['default'], value['format'])
 
                 types = {'string': str, 'decimal': Decimal, 'integer': int, 'date': datetime}
                 if value['default'] is not None and not isinstance(value['default'], types[value['type']]):

--- a/fixedwidth/tests/fixedwidth_test.py
+++ b/fixedwidth/tests/fixedwidth_test.py
@@ -103,7 +103,7 @@ SAMPLE_CONFIG = {
     "date": {
         "required": False,
         "type": "date",
-        "default": datetime.datetime.strptime('20170101', '%Y%m%d'),
+        "default": "20170101",
         "start_pos": 101,
         "end_pos": 108,
         "alignment": "right",


### PR DESCRIPTION
This is the same problem as issue #7 applied to the new 'date' type,
and the same solution as applied in #8, i.e. coercing string into
a datetime at initialization time.